### PR TITLE
refactor: modernize TypeScript config and shared auth types

### DIFF
--- a/src/require-context.d.ts
+++ b/src/require-context.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Minimal declaration for webpack's `require.context` used by the
+ * internationalization loader. This removes the dependency on the
+ * `webpack-env` type definitions, which are no longer maintained.
+ */
+interface WebpackRequire extends NodeRequire {
+  context(path: string, deep?: boolean, filter?: RegExp): any;
+}
+
+declare const require: WebpackRequire;

--- a/src/store/modules/Auth.ts
+++ b/src/store/modules/Auth.ts
@@ -1,22 +1,10 @@
 import {Action, getModule, Module, Mutation, VuexModule} from 'vuex-module-decorators';
 import store from '@/store';
-import {IRegisterInput, IUser} from '@/store/modules/Auth';
+import {IUser, IRegisterInput} from '@/store/types/Auth';
 import {graphqlClient} from '@/store/api';
 import {tokenModule} from '@/store/modules/Token';
 
-export interface IUser {
-  id: string;
-  name: string;
-  email: string;
-}
-
 export interface ILoginInput {
-  email: string;
-  password: string;
-}
-
-export interface IRegisterInput {
-  username: string;
   email: string;
   password: string;
 }

--- a/src/store/modules/Token.ts
+++ b/src/store/modules/Token.ts
@@ -1,19 +1,7 @@
 import {Action, getModule, Module, Mutation, VuexModule} from 'vuex-module-decorators';
 import store from '@/store';
 import {LocalItem} from '@/store/LocalItem';
-import {IUser} from '@/store/modules/Auth';
-
-export interface IUser {
-  id: string;
-  name: string;
-  email: string;
-}
-
-export interface IRegisterInput {
-  username: string;
-  email: string;
-  password: string;
-}
+import {IUser, IRegisterInput} from '@/store/types/Auth';
 
 interface IRegisterResult {
   user: IUser;

--- a/src/store/types/Auth.ts
+++ b/src/store/types/Auth.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared authentication-related TypeScript interfaces.
+ */
+export interface IUser {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export interface IRegisterInput {
+  username: string;
+  email: string;
+  password: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "strict": true,
     "jsx": "preserve",
-    "importHelpers": true,
+    "importHelpers": false,
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "esModuleInterop": true,
@@ -12,9 +12,7 @@
     "sourceMap": true,
     "baseUrl": ".",
     "types": [
-      "webpack-env",
       "webpack",
-      "webpack-env",
       "jest"
     ],
     "paths": {


### PR DESCRIPTION
## Summary
- drop deprecated webpack-env typings and rely on local require.context declaration
- centralize auth interfaces to avoid duplication across modules
- adjust TypeScript configuration for standalone builds without tslib

## Testing
- `npm run lint`
- `npm run test:unit -- --runInBand --verbose`


------
https://chatgpt.com/codex/tasks/task_e_6897679af7f4832abec02a7548405c95