### PR TITLE
chore: strengthen typings for i18n and main entry

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -6,7 +6,7 @@ Vue.use(VueI18n);
 function loadLocaleMessages(): LocaleMessages {
   const locales = require.context('./locales', true, /[A-Za-z0-9-_,\s]+\.json$/i);
   const messages: LocaleMessages = {};
-  locales.keys().forEach((key) => {
+  locales.keys().forEach((key: string) => {
     const matched = key.match(/([A-Za-z0-9-_]+)\./i);
     if (matched && matched.length > 1) {
       const locale = matched[1];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,27 +1,31 @@
-import Vue from 'vue';
+import Vue, { CreateElement } from 'vue';
 import App from './App.vue';
 import router from './router';
 import store from './store';
 import './registerServiceWorker';
 import '@/assets/tailwind.css';
 import i18n from './i18n';
-import {configure} from 'vee-validate';
-import {VeeValidateConfig} from 'vee-validate/dist/types/config';
+import { configure } from 'vee-validate';
+import { VeeValidateConfig } from 'vee-validate/dist/types/config';
+
+/**
+ * Expected properties available in the default message generator of vee-validate.
+ */
+interface ValidationValues extends Record<string, unknown> {
+  _rule_: string;
+}
 
 Vue.config.productionTip = false;
 
 configure({
   // this will be used to generate messages.
-  defaultMessage: (_, values) => {
-    if (values) {
-      return i18n.t(`validations.${values._rule_}`, values);
-    }
-  },
+  defaultMessage: (_: unknown, values: ValidationValues): string =>
+    i18n.t(`validations.${values._rule_}`, values),
 } as Partial<VeeValidateConfig>);
 
 new Vue({
   router,
   store,
   i18n,
-  render: (h) => h(App),
+  render: (h: CreateElement) => h(App),
 }).$mount('#app');


### PR DESCRIPTION
## Summary
- type locale keys as strings when loading messages
- add explicit typings for vee-validate config and Vue render function

## Testing
- `npm run test:unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68977069eecc832a820122f9838b0ddf